### PR TITLE
fix: openai valid kwargs fix

### DIFF
--- a/tromero_tailor/wrapper.py
+++ b/tromero_tailor/wrapper.py
@@ -32,7 +32,7 @@ class MockCompletions(Completions):
     def _format_kwargs(self, kwargs):
         keys_to_keep = [
             "best_of", "decoder_input_details", "details", "do_sample", 
-            "max_new_tokens", "ignore_eos_token", "repetition_penalty", 
+            "max_tokens", "ignore_eos_token", "repetition_penalty", 
             "return_full_outcome", "seed", "stop", "temperature", "top_k", 
             "top_p", "truncate", "typical_p", "watermark", "schema", 
             "adapter_id", "adapter_source", "merged_adapters", "response_format"


### PR DESCRIPTION
in this PR: 

fixed one of the kwargs that are used by openAI:
before: max_new_tokens
new: max_tokens